### PR TITLE
Added Rate Limiting Queue and Wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ It includes helpers to do the following :
 **Matches**
 - Load and filter matches
 - Load a specific match
+- Load Telemetry Files
+
+**General API**
+- Handle API Rate limits
 
 
 ## Table of contents
@@ -26,6 +30,7 @@ It includes helpers to do the following :
 
 ## Usage
 
+### Importation
 After installation, you can import the module to your project using require. 
 ```javascript
 const Pubgapi = require('pubg-api');
@@ -34,6 +39,8 @@ const apiInstance = new Pubgapi('<apiKey>');
 ```
 The module exposes a class that represents an instance of the api, given an [official API key](https://developer.playbattlegrounds.com/) that you must provide.
 
+
+### Making Calls
 You can then interract with the instance of the API. All routes use promises by default. 
 
 For example :
@@ -47,11 +54,21 @@ apiInstance
     });
 ```
 
+### Customization
+By providing an optional second parameter on creation of the API instance you can override a number of default settings. This parameter is an object with the following keys:
+- `asyncType`  whether to return Promises or Observables [default promise]
+- `defaultShard` The server shard to query [default pc-na]
+- `deferRequests` Whether to enable rate limiting, by deferring api requests until your limit allows for another API call [default true]
+- `tokenRate` The custom rate limit for your app in requests per minute (see your developer account) [default 10]
+
+More details on each of these customization options below:
+
+**Observables**
 You can force the wrapper to return [rxjs' Observables](https://github.com/reactivex/rxjs) only by specifying with the asyncType options:
 ```javascript
 const apiInstance = new PubgApi('<apiKey>', {asyncType: 'observable'});
 ```
-or 
+or (after instance creation)
 ```javascript
 apiInstance.asyncType = 'observable';
 ```
@@ -64,6 +81,30 @@ apiInstance
     }, err => {
         // handle error
     });
+```
+
+**Shard**
+You can specify the default shard by using the optional parameter:
+```javascript
+const apiInstance = new PubgApi('<apiKey>', {defaultShard: 'selected-shard'});
+```
+or (after instance creation)
+```javascript
+apiInstance.defaultShard = 'selected-shard';
+```
+
+In addition, all player and matches routes have an optional second parameter where you can specify a shard to query for one individual api call
+
+**Rate Limiting**
+Rate limiting is enabled by default.
+When enabled all API requests (matches or players route) will return a promise (or observable) and store that promise inside of an internal queue. When the user is within their request limit it will resolve these promises on a First in First out basis at an interval defined by the tokenRate provided.
+To override this functionality you can once again instantiate the API instance using the options parameters:
+```javascript
+const apiInstance = new PubgApi('<apiKey>', {deferRequests: false});
+```
+To enable or disable rate limiting after instantiation, use the setRateLimiting() function, this will ensure that all currently deferred requests are released (if disabling) or restarts the API rate loop (if enabling)
+```javascript
+apiInstance.setRateLimiting(enabled, tokenRate);
 ```
 
 ## Status
@@ -130,7 +171,9 @@ The goal of this wrapper is to simplify access to the API, and give a broader sp
 
 This includes developping functions that computes multiple API calls and responses.
 
-- [ ] Implement [Telemetry](https://developer.playbattlegrounds.com/docs/en/telemetry.html) 
+- [x] Implement [Telemetry](https://developer.playbattlegrounds.com/docs/en/telemetry.html) 
 - [x] Implement [rxjs observable](https://github.com/reactivex/rxjs) alternative to promise
-- [ ] Allow selecting a specific shard for each call, instead of setting a default shard
-- [ ] Wrap multiple shard functions
+- [x] Implement rate limiting
+- [x] Allow selecting a specific shard for each call, instead of setting a default shard
+- [x] Wrap multiple shard functions
+- [ ] Helper functions to quickly ascertain match data (winning roster, etc.)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const apiInstance = new Pubgapi('<apiKey>');
 ```
 The module exposes a class that represents an instance of the api, given an [official API key](https://developer.playbattlegrounds.com/) that you must provide.
 
-You can then interract with the instance of the API. All routes use promises by defaut. 
+You can then interract with the instance of the API. All routes use promises by default. 
 
 For example :
 ```javascript

--- a/src/classes/api.js
+++ b/src/classes/api.js
@@ -157,8 +157,8 @@ class PubgApi {
   *
   * @param {{playerName: string, playerIds: string}} params - An object with one or
   * many of the following params:
-  * - playerNames : in game name (IGN) of a player. Separated by coma.
-  * - playerIds : a list of player ids (e.g. account.adadadadaadadadad) separated by coma.
+  * - playerNames : in game name (IGN) of a player. Separated by comma.
+  * - playerIds : a list of player ids (e.g. account.adadadadaadadadad) separated by comma.
   * @param {string} shard - The shard id. If not specifed, calls the default shard.
   * @returns {Promise<any>} A Promise with the result or an error
   */
@@ -176,8 +176,8 @@ class PubgApi {
   * https://documentation.playbattlegrounds.com/en/players.html#/Players/get_players
   *
   * @param {object} params - An object with one or many of the following params:
-  * - playerNames : in game name (IGN) of a player. Separated by coma.
-  * - playerIds : a list of player ids (e.g. account.adadadadaadadadad) separated by coma.
+  * - playerNames : in game name (IGN) of a player. Separated by comma.
+  * - playerIds : a list of player ids (e.g. account.adadadadaadadadad) separated by comma.
   * @param {string} shard - The shard id. If not specifed, calls the default shard.
     * @returns {Promise<any>} A Promise with the result or an error
   */

--- a/src/classes/api.js
+++ b/src/classes/api.js
@@ -15,6 +15,83 @@ const Match = require('./match');
  *  - Kyle Ruscigno <kyleruscigno@gmail.com> : https://github.com/kyleruscigno
  */
 
+
+/**
+* class for limiting and queueing API requests
+*/
+class Limiter {
+  /**
+  * Sets up the Rate Limiter
+  * @param {boolean} enabled - whether to use rate limiting
+  * @param {int} tokenRate - Your amount of API request tokens per minute
+  *
+  */
+
+  constructor(enabled, tokenRate) {
+    this.items = [];
+    this.enabled = enabled;
+    this.remaining = tokenRate;
+    this.refillRate = (6000 / this.remaining);
+    this.resetTime = this.refillRate;
+    this.release();
+  }
+
+  /**
+  * Called from requestAPI, updates the remaining request tokens
+  * and time to refill from any response headers
+  */
+  update(remaining, resetTime) {
+    this.remaining = remaining;
+    this.resetTime = resetTime / 1000000; //rate time is in nanoseconds - convert to milliseconds 
+  }
+
+  /**
+  * Defer an API Request until request tokens are available
+  * if available or rate limiting is not enabled, return immediately
+  */
+  defer() {
+    if (this.enabled && this.remaining < 1) {
+      return new Promise((resolve, reject) => {
+        this.items.push(resolve);
+      });
+    }
+    return Promise.resolve();
+  }
+
+  /**
+  * Remove a Deferred Request from the queue (FIFO)
+  * resolve the defer() promises resolve function allowing requestAPI to continue
+  * update remaining tokens since pending request will subtract
+  */
+  finish() {
+    if (this.items.length) {
+      this.remaining -= 1;
+      const resolve = this.items.shift();
+      resolve();
+    }
+  }
+
+  /**
+  * Infinite Loop, called every time a rate token generates
+  * Finish as many deferred API requests as possible and then reschedule
+  * If update() was called in the interim, resetTime can be smaller than refill rate
+  */
+  release() {
+    if (!this.enabled) return;
+    const self = this;
+    setTimeout( function() {
+      self.remaining += 1;
+      const remaining = self.remaining;
+      for (let i = 0; i < remaining; i += 1) {
+        self.finish();
+      }
+      self.release();
+    }, self.resetTime);
+    this.resetTime = this.refillRate;
+  }
+}
+
+
 class PubgApi {
   /**
   * Sets up the api key to use, and the default shard to request.
@@ -40,6 +117,8 @@ class PubgApi {
   constructor(apiKey, options = {
     asyncType: 'promise',
     defaultShard: 'pc-na',
+    deferRequests: true,
+    tokenRate: 10,
   }) {
     this.apiKey = apiKey;
     this.apiURL = 'api.playbattlegrounds.com';
@@ -50,6 +129,7 @@ class PubgApi {
       matches: 'matches',
       players: 'players',
     };
+    this.limiter = new Limiter(options.deferRequests || true, options.tokenRate || 10);
 
     if (this.asyncType !== 'promise' && this.asyncType !== 'observable') {
       throw new Error('Unknown async type. Should be promise or observable');
@@ -78,7 +158,25 @@ class PubgApi {
   }
 
   /**
+  * Sets whether or not API Requests should be deferred
+  * until their is available request tokens
+  * restarts the refill/queue loop if it was previously off
+  *
+  * @param {boolean} enabled - whether to use rate limiting
+  * @param {int} tokenRate - Your amount of API request tokens per minute
+  */
+  setRateLimiting(enabled, tokenRate) {
+    this.limiter.enabled = enabled;
+    this.limiter.refillRate = (6000 / tokenRate);
+    this.limiter.release();
+  }
+
+  /**
   * Sends a request to the pubg api server, and returns a promise with the result.
+  *
+  * Places an API request on the defer queue (if enabled)
+  * If available request tokens it will process immediately
+  * otherwise, adds to queue and resolved in order of requests
   *
   * @param {string} shard - The shard to request.
   * @param {string} route - The URI to call. Corresponds to the part of the route after the shard.
@@ -88,40 +186,44 @@ class PubgApi {
   * @returns {Promise<any>} A promise with the result, or an error
   */
   requestAPI(shard, route, params) {
-    return new Promise((resolve, reject) => {
-      let queryParams = '';
-      if (params) {
-        Object.keys(params).forEach((key) => {
-          queryParams += queryParams.length ? `&${key}=${params[key]}` : `?${key}=${params[key]}`;
-        });
-      }
-      const headers = {
-        Accept: 'application/vnd.api+json',
-        Authorization: `Bearer ${this.apiKey}`,
-      };
-      let rawData = '';
-      const req = https.get({
-        hostname: this.apiURL,
-        path: `/shards/${shard}/${route}${queryParams}`,
-        headers,
-      }, (res) => {
-        res.setEncoding('utf8');
-        res.on('data', (data) => {
-          rawData += data;
-        });
-        res.on('end', () => {
-          try {
-            const parsedData = JSON.parse(rawData);
-            if (res.statusCode >= 400) {
-              return reject(parsedData);
+    return this.limiter.defer().then(() => {
+      return new Promise((resolve, reject) => {
+        let queryParams = '';
+        if (params) {
+          Object.keys(params).forEach((key) => {
+            queryParams += queryParams.length ? `&${key}=${params[key]}` : `?${key}=${params[key]}`;
+          });
+        }
+        const headers = {
+          Accept: 'application/vnd.api+json',
+          Authorization: `Bearer ${this.apiKey}`,
+        };
+        let rawData = '';
+        const req = https.get({
+          hostname: this.apiURL,
+          path: `/shards/${shard}/${route}${queryParams}`,
+          headers,
+        }, (res) => {
+          res.setEncoding('utf8');
+          const resheaders = res.headers;
+          this.limiter.update(resheaders['X-RateLimit-Remaining'], resheaders['X-RateLimit-Reset']);
+          res.on('data', (data) => {
+            rawData += data;
+          });
+          res.on('end', () => {
+            try {
+              const parsedData = JSON.parse(rawData);
+              if (res.statusCode >= 400) {
+                return reject(parsedData);
+              }
+              return resolve(parsedData);
+            } catch (err) {
+              return reject(err);
             }
-            return resolve(parsedData);
-          } catch (err) {
-            return reject(err);
-          }
+          });
         });
+        req.on('error', e => reject(e));
       });
-      req.on('error', e => reject(e));
     });
   }
 

--- a/src/classes/api.js
+++ b/src/classes/api.js
@@ -73,7 +73,12 @@ class Limiter {
   * Finish as many deferred API requests as possible and then reschedule
   */
   release() {
-    if (!this.enabled) return;
+    if (!this.enabled) {
+      for (let i = 0; i < this.items.length; i += 1) {
+        this.finish();
+      }
+      return;
+    }
     for (let i = 0; i < this.remaining; i += 1) {
       this.finish();
     }


### PR DESCRIPTION
Added Rate Limiting functions and classes to API requests.
- Limiter class creates a request queue
- All API Requests ping the queue - receiving a Promise object
- If rate limiting is disabled or there are available request tokens the promise resolves immediately & the method continues to the actual API request
- If enabled and there are not available tokens, the Promises resolve function is held by the limiter, and completed at a later time by the limiter (in the order that requests were added to the queue)
- 2 new params for PubgAPI constructor - deferRequests and tokenRate (whether to use rate limiting, amount of request tokens per minute for apikey)
